### PR TITLE
Fix env loading

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,3 +18,9 @@ class Settings:
         if value is None:
             value = ""
         return value
+    
+    def get_crawler_api_key(self) -> str:
+        value = os.getenv("CRAWLER_API_KEY")
+        if value is None:
+            value = ""
+        return value

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,12 +1,12 @@
-import os
 from typing import Optional
 
-from dotenv import find_dotenv, load_dotenv
 from fastapi import Header, HTTPException
 
 from app.core.config import Settings
 
 settings = Settings()
+if settings.get_crawler_api_key() == "":
+    raise ValueError("CRAWLER_API_KEY environment variable is not set.")
 
 async def get_token_header(token: Optional[str] = Header(None)):
     if token != settings.get_crawler_api_key():

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,14 +1,13 @@
 import os
 from typing import Optional
 
+from dotenv import find_dotenv, load_dotenv
 from fastapi import Header, HTTPException
 
-CRAWLER_API_KEY = os.getenv("CRAWLER_API_KEY")
+from app.core.config import Settings
 
-if not CRAWLER_API_KEY:
-    raise RuntimeError("CRAWLER_API_KEY environment variable is not set")
-
+settings = Settings()
 
 async def get_token_header(token: Optional[str] = Header(None)):
-    if token != CRAWLER_API_KEY:
+    if token != settings.get_crawler_api_key():
         raise HTTPException(status_code=403)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ types-requests = "2.32.0.20250328"
 bs4 = "0.0.2"
 scrapy = "2.13.0"
 parsel = "1.10.0"
+uvicorn = "^0.34.2"
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
- crawler key wasn't loaded from .env file, only from os env
- added uvicorn to pyproject.toml, should now be installed with poetry install