### PR TITLE
67: Daily Newsletter

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -36,3 +36,9 @@ class Settings:
         if value is None:
             value = ""
         return value
+
+    def get_brevo_api_key(self) -> str:
+        value = os.getenv("BREVO_API_KEY")
+        if value is None:
+            value = ""
+        return value

--- a/app/core/email.py
+++ b/app/core/email.py
@@ -33,24 +33,23 @@ class EmailService:
         return f"{anonymized_local}@{domain}"
 
     @staticmethod
-    def _anonymize_email_list(emails: list[str]) -> str:
-        anonymized = [EmailService._anonymize_email(email) for email in emails]
-        return ", ".join(anonymized)
-
-    @staticmethod
     def send_email(email: Email):
-        sender = {"name": "OpenEU", "email": "mail@openeu.csee.tech"}
-        to = [{"email": recipient} for recipient in email.recipients]
-        email_data = brevo_python.SendSmtpEmail(
-            to=to,
-            html_content=email.html_body,
-            sender=sender,
-            subject=email.subject,
-        )
+        if len(email.recipients) == 0:
+            EmailService.logger.warning("No recipients provided for email, doing nothing")
 
-        try:
-            EmailService.client.send_transac_email(email_data)
-            anonymized_recipients = EmailService._anonymize_email_list(email.recipients)
-            EmailService.logger.info(f"Email sent successfully to {anonymized_recipients}")
-        except ApiException as e:
-            EmailService.logger.error(f"Error sending email: {e}")
+        for recipient in email.recipients:
+            sender = {"name": "OpenEU", "email": "mail@openeu.csee.tech"}
+            to = [{"email": recipient}]
+            email_data = brevo_python.SendSmtpEmail(
+                to=to,
+                html_content=email.html_body,
+                sender=sender,
+                subject=email.subject,
+            )
+
+            try:
+                EmailService.client.send_transac_email(email_data)
+                anonymized_recipient = EmailService._anonymize_email(recipient)
+                EmailService.logger.info(f"Email sent successfully to {anonymized_recipient}")
+            except ApiException as e:
+                EmailService.logger.error(f"Error sending email: {e}")

--- a/app/core/email.py
+++ b/app/core/email.py
@@ -1,0 +1,38 @@
+import logging
+
+import brevo_python
+from brevo_python.rest import ApiException
+
+from app.core.config import Settings
+
+
+class Email:
+    def __init__(self, subject: str, html_body: str, recipients: list[str]):
+        self.subject = subject
+        self.html_body = html_body
+        self.recipients = recipients
+
+
+class EmailService:
+    logger = logging.getLogger(__name__)
+    settings = Settings()
+    configuration = brevo_python.Configuration()
+    configuration.api_key["api-key"] = settings.get_brevo_api_key()
+    client = brevo_python.TransactionalEmailsApi(brevo_python.ApiClient(configuration))
+
+    @staticmethod
+    def send_email(email: Email):
+        sender = {"name": "OpenEU", "email": "mail@openeu.csee.tech"}
+        to = [{"email": recipient} for recipient in email.recipients]
+        email_data = brevo_python.SendSmtpEmail(
+            to=to,
+            html_content=email.html_body,
+            sender=sender,
+            subject=email.subject,
+        )
+
+        try:
+            EmailService.client.send_transac_email(email_data)
+            EmailService.logger.info(f"Email sent successfully to {', '.join(email.recipients)}")
+        except ApiException as e:
+            EmailService.logger.error(f"Error sending email: {e}")

--- a/app/core/jobs.py
+++ b/app/core/jobs.py
@@ -1,6 +1,9 @@
+import logging
 from datetime import datetime
 
+from app.core.email import Email, EmailService
 from app.core.scheduling import scheduler
+from app.core.supabase_client import supabase
 from app.data_sources.apis.mep import fetch_and_store_current_meps
 from app.data_sources.scrapers.ipex_calender_scraper import IPEXCalendarAPIScraper
 from app.data_sources.scrapers.mec_sum_minist_meetings_scraper import MECSumMinistMeetingsScraper
@@ -9,6 +12,8 @@ from app.data_sources.scrapers.mep_meetings_scraper import scrape_and_store_meet
 
 DAILY_INTERVAL_MINUTES = 24 * 60
 WEEKLY_INTERVAL_MINUTES = 7 * DAILY_INTERVAL_MINUTES
+
+logger = logging.getLogger(__name__)
 
 
 def scrape_ipex_calendar():
@@ -33,6 +38,18 @@ def scrape_mec_sum_minist_meetings():
     scraper.scrape(today, today)
 
 
+def send_daily_newsletter():
+    users = supabase.auth.admin.list_users()
+    email_addresses = [user.email for user in users]
+    email_message = Email(
+        subject="OpenEU Daily Newsletter",
+        html_body="<p>Here is your daily newsletter from OpenEU.</p>",
+        recipients=email_addresses,
+    )
+    logger.info(f"Sending daily newsletter to {len(email_addresses)} users: {email_message.recipients}")
+    EmailService.send_email(email=email_message)
+
+
 def setup_scheduled_jobs():
     scheduler.register("fetch_and_store_current_meps", fetch_and_store_current_meps, WEEKLY_INTERVAL_MINUTES)
     scheduler.register(
@@ -41,3 +58,4 @@ def setup_scheduled_jobs():
     scheduler.register("scrape_mep_meetings", scrape_mep_meetings, DAILY_INTERVAL_MINUTES)
     scheduler.register("scrape_ipex_calendar", scrape_ipex_calendar, DAILY_INTERVAL_MINUTES)
     scheduler.register("scrape_mec_sum_minist_meetings", scrape_mec_sum_minist_meetings, DAILY_INTERVAL_MINUTES)
+    scheduler.register("send_daily_newsletter", send_daily_newsletter, DAILY_INTERVAL_MINUTES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ uvicorn = "^0.34.2"
 crawl4ai = "0.6.3"
 types-python-dateutil = "2.9.0.20250516"
 deepl = "^1.22.0"
+brevo-python = "^1.1.2"
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
* Adds functionality to send transactional emails using Brevo (⚠️ requires new API Key to be set up in deployment)
* Sends a daily dummy newsletter to all users registered in supabase (caution, limited to 300 emails/day on the free plan)