### PR TITLE
111 store scheduled job status

### DIFF
--- a/app/core/jobs.py
+++ b/app/core/jobs.py
@@ -25,35 +25,35 @@ logger = logging.getLogger(__name__)
 
 def scrape_eu_laws_by_topic():
     lawtracker = LawTrackerSpider()
-    lawtracker.scrape()
+    return lawtracker.scrape()
 
 
 def scrape_ipex_calendar():
     ipex_scraper = IPEXCalendarAPIScraper()
-    ipex_scraper.scrape()
+    return ipex_scraper.scrape()
 
 
 def scrape_meeting_calendar_for_current_day():
     now = datetime.now()
     ep_meeting_scraper = EPMeetingCalendarScraper(now, now)
-    ep_meeting_scraper.scrape()
+    return ep_meeting_scraper.scrape()
 
 
 def scrape_mep_meetings():
     today = datetime.now().date()
     scraper = MEPMeetingsScraper(start_date=today, end_date=today)
-    scraper.scrape()
+    return scraper.scrape()
 
 
 def scrape_mec_sum_minist_meetings():
     today = datetime.now().date()
     scraper = MECSumMinistMeetingsScraper(start_date=today, end_date=today)
-    scraper.scrape()
+    return scraper.scrape()
 
 
 def scrape_belgian_parliament_meetings():
     today = datetime.now().date()
-    run_belgian_parliament_scraper(start_date=today, end_date=today)
+    return run_belgian_parliament_scraper(start_date=today, end_date=today)
 
 
 def send_daily_newsletter():
@@ -71,24 +71,24 @@ def send_daily_newsletter():
 def scrape_mec_prep_bodies_meetings():
     today = datetime.now().date()
     scraper = MECPrepBodiesMeetingsScraper(start_date=today, end_date=today)
-    scraper.scrape()
+    return scraper.scrape()
 
 
 def scrape_austrian_parliament_meetings():
     start_date = datetime.now().date()
-    run_scraper(start_date)
+    return run_scraper(start_date)
 
 
 def scrape_polish_presidency_meetings():
     today = datetime.now().date()
     scraper = PolishPresidencyMeetingsScraper(start_date=today, end_date=today)
-    scraper.scrape()
+    return scraper.scrape()
 
 
 def scrape_spanish_commission_meetings():
     today = datetime.now().date()
     scraper = SpanishCommissionScraper(date=today)
-    scraper.scrape()
+    return scraper.scrape()
 
 
 def clean_up_embeddings():

--- a/app/core/scheduling.py
+++ b/app/core/scheduling.py
@@ -61,7 +61,6 @@ class ScheduledJob:
                 self.success = True
             except Exception as e:
                 self.logger.error(f"Error in job '{self.name}': {e}")
-                self.mark_job_error()
                 notify_job_failure(self.name, e)
             finally:
                 self.mark_just_ran()

--- a/app/core/scheduling.py
+++ b/app/core/scheduling.py
@@ -42,8 +42,8 @@ class ScheduledJob:
                 {
                     "name": self.name,
                     "last_run_at": now.isoformat(),
-                    "success": self.result.success,
-                    "inserted_rows": self.result.inserted_rows,
+                    "success": True if self.result is None else self.result.success,
+                    "inserted_rows": 0 if self.result is None else self.result.lines_added,
                 },
                 on_conflict=["name"],
             ).execute()

--- a/app/core/scheduling.py
+++ b/app/core/scheduling.py
@@ -18,6 +18,7 @@ class ScheduledJob:
         self.interval = interval
         self.grace = timedelta(seconds=grace_seconds)
         self.last_run_at: datetime | None = None
+        self.success: bool = False
         self.result: ScraperResult | None = None
 
         try:
@@ -43,25 +44,8 @@ class ScheduledJob:
                 {
                     "name": self.name,
                     "last_run_at": now.isoformat(),
-                    "success": True if self.result is None else self.result.success,
+                    "success": self.success if self.result is None else self.result.success,
                     "inserted_rows": 0 if self.result is None else self.result.lines_added,
-                },
-                on_conflict=["name"],
-            ).execute()
-        except Exception as e:
-            self.logger.error(f"Failed to update last run time for job '{self.name}': {e}")
-
-    def mark_job_error(self):
-        now = datetime.now()
-        self.last_run_at = now
-        try:
-            # Some jobs are not scraper jobs and there don't return a scraper result. Handle it by checking for None.
-            supabase.table(TABLE_NAME).upsert(
-                {
-                    "name": self.name,
-                    "last_run_at": now.isoformat(),
-                    "success": False,
-                    "inserted_rows": 0,
                 },
                 on_conflict=["name"],
             ).execute()
@@ -70,9 +54,11 @@ class ScheduledJob:
 
     def run_async(self):
         def _run():
+            self.success = False
             try:
                 self.logger.info(f"Running job '{self.name}' at {datetime.now()}")
                 self.result = self.func()
+                self.success = True
             except Exception as e:
                 self.logger.error(f"Error in job '{self.name}': {e}")
                 self.mark_job_error()

--- a/app/core/scheduling.py
+++ b/app/core/scheduling.py
@@ -20,6 +20,7 @@ class ScheduledJob:
         self.last_run_at: datetime | None = None
         self.success: bool = False
         self.result: ScraperResult | None = None
+        self.error: Exception | None = None
 
         try:
             result = supabase.table(TABLE_NAME).select("last_run_at").eq("name", name).execute()
@@ -40,14 +41,15 @@ class ScheduledJob:
         self.last_run_at = now
         try:
             # Some jobs are not scraper jobs and there don't return a scraper result. Handle it by checking for None.
+            is_result_none = self.result is None
             supabase.table(TABLE_NAME).upsert(
                 {
                     "name": self.name,
                     "last_run_at": now.isoformat(),
-                    "success": self.success if self.result is None else self.result.success,
-                    "inserted_rows": 0 if self.result is None else self.result.lines_added,
+                    "success": self.success if is_result_none else self.result.success,
+                    "inserted_rows": 0 if is_result_none else self.result.lines_added,
+                    "error_msg": repr(self.error) if is_result_none else repr(self.result.error),
                 },
-                on_conflict=["name"],
             ).execute()
         except Exception as e:
             self.logger.error(f"Failed to update last run time for job '{self.name}': {e}")
@@ -55,12 +57,15 @@ class ScheduledJob:
     def run_async(self):
         def _run():
             self.success = False
+            self.error = None
+            self.result = None
             try:
                 self.logger.info(f"Running job '{self.name}' at {datetime.now()}")
                 self.result = self.func()
                 self.success = True
             except Exception as e:
                 self.logger.error(f"Error in job '{self.name}': {e}")
+                self.error = e
                 notify_job_failure(self.name, e)
             finally:
                 self.mark_just_ran()

--- a/app/data_sources/apis/austrian_parliament.py
+++ b/app/data_sources/apis/austrian_parliament.py
@@ -203,13 +203,13 @@ class AustrianParliamentScraper(ScraperBase):
 
         except requests.RequestException as e:
             logger.error(f"Network error: {e}")
-            return ScraperResult(False, e, self.last_entry)
+            return ScraperResult(False, error=e, last_entry=self.last_entry)
         except json.JSONDecodeError as e:
             logger.error(f"JSON decode error: {e}")
-            return ScraperResult(False, e, self.last_entry)
+            return ScraperResult(False, error=e, last_entry=self.last_entry)
         except Exception as e:
             logger.error(f"Unexpected error: {e}")
-            return ScraperResult(False, e, self.last_entry)
+            return ScraperResult(False, error=e, last_entry=self.last_entry)
 
 
 def run_scraper(start_date: Optional[date] = None, end_date: Optional[date] = None):

--- a/app/data_sources/scraper_base.py
+++ b/app/data_sources/scraper_base.py
@@ -16,8 +16,9 @@ brussels_tz = ZoneInfo("Europe/Brussels")
 
 
 class ScraperResult:
-    def __init__(self, success: bool, error: Optional[Exception] = None, last_entry: Optional[Any] = None) -> None:
+    def __init__(self, success: bool, lines_added: number = 0, error: Optional[Exception] = None, last_entry: Optional[Any] = None) -> None:
         self.success = success
+        self.lines_added = lines_added
         self.error = error
         self.last_entry = last_entry
 
@@ -30,6 +31,7 @@ class ScraperBase(ABC):
         self.table_name = table_name
         self.max_retries = max_retries
         self.retry_delay = retry_delay
+        self.lines_added = 0
         self._last_entry = None
 
     def scrape(self, **args) -> ScraperResult:
@@ -51,6 +53,7 @@ class ScraperBase(ABC):
             if attempt <= self.max_retries:
                 time.sleep(self.retry_delay)
 
+        result.lines_added = self.lines_added
         return result  # Last result after retries
 
     @property
@@ -84,7 +87,7 @@ class ScraperBase(ABC):
             return None
         except Exception as e:
             logger.error(f"Error storing entry in Supabase: {e}")
-            return ScraperResult(False, e, self.last_entry)
+            return ScraperResult(False, self.lines_added, e, self.last_entry)
 
     def store_entry_returning_id(self, entry: Any, on_conflict: Optional[str] = None) -> Optional[str]:
         """
@@ -92,6 +95,7 @@ class ScraperBase(ABC):
         """
         try:
             response = supabase.table(self.table_name).upsert(entry, on_conflict=on_conflict).execute()
+            self.lines_added += 1
             return response.data[0].get("id") if response.data else None
         except Exception as e:
             logger.error(f"Error storing entry in Supabase: {e}")

--- a/app/data_sources/scraper_base.py
+++ b/app/data_sources/scraper_base.py
@@ -16,7 +16,10 @@ brussels_tz = ZoneInfo("Europe/Brussels")
 
 
 class ScraperResult:
-    def __init__(self, success: bool, lines_added: int = 0, error: Optional[Exception] = None, last_entry: Optional[Any] = None) -> None:
+    def __init__(self, success: bool,
+                 lines_added: int = 0,
+                 error: Optional[Exception] = None,
+                 last_entry: Optional[Any] = None) -> None:
         self.success = success
         self.lines_added = lines_added
         self.error = error
@@ -76,7 +79,7 @@ class ScraperBase(ABC):
                 )
 
     def store_entry(
-        self, entry, on_conflict: Optional[str] = None, embedd_entries: bool = True
+            self, entry, on_conflict: Optional[str] = None, embedd_entries: bool = True
     ) -> Optional[ScraperResult]:
         try:
             # add/update scraped_at timestamp

--- a/app/data_sources/scraper_base.py
+++ b/app/data_sources/scraper_base.py
@@ -16,7 +16,7 @@ brussels_tz = ZoneInfo("Europe/Brussels")
 
 
 class ScraperResult:
-    def __init__(self, success: bool, lines_added: number = 0, error: Optional[Exception] = None, last_entry: Optional[Any] = None) -> None:
+    def __init__(self, success: bool, lines_added: int = 0, error: Optional[Exception] = None, last_entry: Optional[Any] = None) -> None:
         self.success = success
         self.lines_added = lines_added
         self.error = error

--- a/app/data_sources/scraper_base.py
+++ b/app/data_sources/scraper_base.py
@@ -87,7 +87,7 @@ class ScraperBase(ABC):
             response = supabase.table(self.table_name).upsert(entry, on_conflict=on_conflict).execute()
             if embedd_entries:
                 self.embedd_entries(response)
-            self.lines_added += 1
+            self.lines_added += len(response.data) if response.data else 0
             return None
         except Exception as e:
             logger.error(f"Error storing entry in Supabase: {e}")

--- a/app/data_sources/scraper_base.py
+++ b/app/data_sources/scraper_base.py
@@ -87,6 +87,7 @@ class ScraperBase(ABC):
             response = supabase.table(self.table_name).upsert(entry, on_conflict=on_conflict).execute()
             if embedd_entries:
                 self.embedd_entries(response)
+            self.lines_added += 1
             return None
         except Exception as e:
             logger.error(f"Error storing entry in Supabase: {e}")

--- a/app/data_sources/scrapers/ipex_calender_scraper.py
+++ b/app/data_sources/scrapers/ipex_calender_scraper.py
@@ -166,9 +166,9 @@ class IPEXCalendarAPIScraper(ScraperBase):
         logger.info("Starting IPEX calendar scraping via API...")
 
         if "start_date" not in args:
-            return ScraperResult(False, Exception('Missing parameter "start_date"'))
+            return ScraperResult(False, error=Exception('Missing parameter "start_date"'))
         if "end_date" not in args:
-            return ScraperResult(False, Exception('Missing parameter "end_date"'))
+            return ScraperResult(False, error=Exception('Missing parameter "end_date"'))
 
         start_date = args.get("start_date")
         end_date = args.get("start_date")
@@ -212,13 +212,13 @@ class IPEXCalendarAPIScraper(ScraperBase):
 
             except requests.RequestException as e:
                 logger.error(f"Network error on page {page_number}: {e}")
-                return ScraperResult(False, e, self.last_entry)
+                return ScraperResult(False, error=e, last_entry=self.last_entry)
             except json.JSONDecodeError as e:
                 logger.error(f"JSON decode error on page {page_number}: {e}")
-                return ScraperResult(False, e, self.last_entry)
+                return ScraperResult(False, error=e, last_entry=self.last_entry)
             except Exception as e:
                 logger.error(f"Unexpected error on page {page_number}: {e}")
-                return ScraperResult(False, e, self.last_entry)
+                return ScraperResult(False, error=e, last_entry=self.last_entry)
 
         logger.info(f"Scraping completed. Total events: {len(self.events)}")
 

--- a/app/data_sources/scrapers/mec_prep_bodies_meetings_scraper.py
+++ b/app/data_sources/scrapers/mec_prep_bodies_meetings_scraper.py
@@ -204,7 +204,7 @@ class MECPrepBodiesMeetingsScraper(ScraperBase):
             return asyncio.run(self.scrape_once_async(last_entry))
         except Exception as e:
             logger.error(f"Error while scraping and storing meetings: {e}")
-            return ScraperResult(False, e, None)
+            return ScraperResult(success=False, error=e)
 
 
 # ------------------------------

--- a/app/data_sources/scrapers/mec_sum_minist_meetings_scraper.py
+++ b/app/data_sources/scrapers/mec_sum_minist_meetings_scraper.py
@@ -281,7 +281,7 @@ class MECSumMinistMeetingsScraper(ScraperBase):
             return asyncio.run(self.scrape_once_async(last_entry))
         except Exception as e:
             logger.error(f"Error while scraping and storing meetings: {e}")
-            return ScraperResult(False, e, None)
+            return ScraperResult(success=False, error=e)
 
 
 # ------------------------------

--- a/supabase/migrations/20250530114016_add_run_results_to_scheduled_job_runs.sql
+++ b/supabase/migrations/20250530114016_add_run_results_to_scheduled_job_runs.sql
@@ -1,5 +1,9 @@
 ALTER TABLE "scheduled_job_runs"
+    DROP CONSTRAINT scheduled_job_runs_pkey CASCADE,
     ADD COLUMN "success" BOOLEAN,
     ADD COLUMN "inserted_rows" BIGINT,
+    ADD COLUMN "error_msg" TEXT,
+    ADD COLUMN id BIGSERIAL,
+    ADD PRIMARY KEY (id),
 ALTER
 COLUMN "last_run_at" SET DEFAULT now();

--- a/supabase/migrations/20250530114016_add_run_results_to_scheduled_job_runs.sql
+++ b/supabase/migrations/20250530114016_add_run_results_to_scheduled_job_runs.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "scheduled_job_runs"
+    ADD COLUMN "success" BOOLEAN,
+    ADD COLUMN "inserted_rows" BIGINT,
+ALTER
+COLUMN "last_run_at" SET DEFAULT now();

--- a/supabase/schemas/scheduled_job_runs.sql
+++ b/supabase/schemas/scheduled_job_runs.sql
@@ -1,4 +1,8 @@
 CREATE TABLE "scheduled_job_runs" (
-  "name" VARCHAR(255) PRIMARY KEY NOT NULL,
-  "last_run_at" TIMESTAMP
+  "id" BIGSERIAL PRIMARY KEY,
+  "name" VARCHAR(255),
+  "last_run_at" TIMESTAMP,
+  "success" BOOLEAN,
+  "inserted_rows" BIGINT,
+  "error_msg" TEXT,
 );


### PR DESCRIPTION
- extended table "scheduled_job_runs" with success & inserted_rows columns
- added migration script for "scheduled_job_runs"
- modified scheduling to save if the job run was:
   - successful
   - the number of rows that were inserted into the database