### PR TITLE
refactor: migrate away from deprecated scrapy call

### DIFF
--- a/app/data_sources/scrapers/mep_meetings_scraper.py
+++ b/app/data_sources/scrapers/mep_meetings_scraper.py
@@ -3,7 +3,7 @@ import math
 import re
 from collections.abc import Generator
 from datetime import date
-from typing import Any, Callable, Optional
+from typing import AsyncGenerator, Callable, Optional
 from urllib.parse import urlencode
 
 import scrapy
@@ -91,7 +91,7 @@ class MEPMeetingsSpider(scrapy.Spider):
         self.result_callback: Optional[Callable[[list[MEPMeeting]], None]] = result_callback
         self.meetings: list[MEPMeeting] = []
 
-    def start_requests(self) -> Generator[scrapy.Request, Any, None]:
+    async def start(self) -> AsyncGenerator[scrapy.Request, None]:
         yield self.scrape_page(0)
 
     def scrape_page(self, page: int) -> scrapy.Request:

--- a/app/data_sources/scrapers/mep_meetings_scraper.py
+++ b/app/data_sources/scrapers/mep_meetings_scraper.py
@@ -92,6 +92,9 @@ class MEPMeetingsSpider(scrapy.Spider):
         self.meetings: list[MEPMeeting] = []
 
     async def start(self) -> AsyncGenerator[scrapy.Request, None]:
+        """
+        Start the spider.
+        """
         yield self.scrape_page(0)
 
     def scrape_page(self, page: int) -> scrapy.Request:

--- a/app/data_sources/scrapers/mep_meetings_scraper.py
+++ b/app/data_sources/scrapers/mep_meetings_scraper.py
@@ -1,9 +1,9 @@
 import logging
 import math
 import re
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from datetime import date
-from typing import AsyncGenerator, Callable, Optional
+from typing import Callable, Optional
 from urllib.parse import urlencode
 
 import scrapy

--- a/app/data_sources/scrapers/polish_presidency_meetings_scraper.py
+++ b/app/data_sources/scrapers/polish_presidency_meetings_scraper.py
@@ -1,8 +1,9 @@
 import logging
 import re
+from collections.abc import AsyncGenerator
 from datetime import date
 from datetime import datetime as dt
-from typing import AsyncGenerator, Callable, Optional
+from typing import Callable, Optional
 from urllib.parse import urlencode
 
 import scrapy

--- a/app/data_sources/scrapers/polish_presidency_meetings_scraper.py
+++ b/app/data_sources/scrapers/polish_presidency_meetings_scraper.py
@@ -1,9 +1,8 @@
 import logging
 import re
-from collections.abc import Generator
 from datetime import date
 from datetime import datetime as dt
-from typing import Any, Callable, Optional
+from typing import AsyncGenerator, Callable, Optional
 from urllib.parse import urlencode
 
 import scrapy
@@ -77,7 +76,10 @@ class PolishPresidencyMeetingsSpider(scrapy.Spider):
         self.result_callback: Optional[Callable[[list[PolishPresidencyMeeting]], None]] = result_callback
         self.meetings: list[PolishPresidencyMeeting] = []
 
-    def start_requests(self) -> Generator[scrapy.Request, Any, None]:
+    async def start(self) -> AsyncGenerator[scrapy.Request, None]:
+        """
+        Called by Scrapy when the spider starts crawling.
+        """
         params = {
             "StartDate": self.start_date.strftime("%Y-%m-%d"),
             "EndDate": self.end_date.strftime("%Y-%m-%d"),
@@ -206,9 +208,7 @@ if __name__ == "__main__":
 
     print("Scraping Polish EU Presidency meetings...")
 
-    scraper = PolishPresidencyMeetingsScraper(
-        start_date=datetime.date(2025, 5, 20), end_date=datetime.date(2025, 5, 21)
-    )
+    scraper = PolishPresidencyMeetingsScraper(start_date=datetime.date(2025, 6, 3), end_date=datetime.date(2025, 6, 3))
     result = scraper.scrape()
     meetings = scraper.entries
     if result.success:

--- a/app/data_sources/scrapers/spanish_commission_scraper.py
+++ b/app/data_sources/scrapers/spanish_commission_scraper.py
@@ -3,8 +3,7 @@
 # ------------------------------
 import datetime
 import logging
-from collections.abc import Generator
-from typing import Callable, Optional
+from typing import AsyncGenerator, Callable, Optional
 
 import scrapy
 from pydantic import BaseModel
@@ -52,7 +51,7 @@ class SpanishCommissionSpider(scrapy.Spider):
         self.translator = DeepLTranslator(translator)
         super().__init__()
 
-    def start_requests(self) -> Generator[scrapy.Request, None, None]:
+    async def start(self) -> AsyncGenerator[scrapy.Request, None]:
         url = f"https://www.congreso.es/en/agenda?p_p_id=agenda&p_p_lifecycle=0&p_p_state=normal&p_p_mode=view&_agenda_mvcPath=cambiaragenda&_agenda_tipoagenda=1&_agenda_dia={self.date.day:02d}&_agenda_mes={self.date.month:02d}&_agenda_anio={self.date.year}"
         yield scrapy.Request(url=url, callback=self.parse_day)
 

--- a/app/data_sources/scrapers/spanish_commission_scraper.py
+++ b/app/data_sources/scrapers/spanish_commission_scraper.py
@@ -3,7 +3,8 @@
 # ------------------------------
 import datetime
 import logging
-from typing import AsyncGenerator, Callable, Optional
+from collections.abc import AsyncGenerator
+from typing import Callable, Optional
 
 import scrapy
 from pydantic import BaseModel

--- a/app/data_sources/scrapers/weekly_agenda_scraper.py
+++ b/app/data_sources/scrapers/weekly_agenda_scraper.py
@@ -1,8 +1,9 @@
 import datetime
 import logging
 import re
+from collections.abc import AsyncGenerator
 from datetime import date, timedelta
-from typing import AsyncGenerator, Callable, Optional
+from typing import Callable, Optional
 
 import scrapy
 from parsel import Selector

--- a/app/data_sources/scrapers/weekly_agenda_scraper.py
+++ b/app/data_sources/scrapers/weekly_agenda_scraper.py
@@ -1,9 +1,8 @@
 import datetime
 import logging
 import re
-from collections.abc import Generator
 from datetime import date, timedelta
-from typing import Callable, Optional
+from typing import AsyncGenerator, Callable, Optional
 
 import scrapy
 from parsel import Selector
@@ -54,7 +53,7 @@ class WeeklyAgendaSpider(scrapy.Spider):
         self.result_callback = result_callback
         self.entries: list[AgendaEntry] = []
 
-    def start_requests(self) -> Generator[scrapy.Request, None, None]:
+    async def start(self) -> AsyncGenerator[scrapy.Request, None]:
         """
         Generate requests for each week in the specified date range.
         """
@@ -519,7 +518,7 @@ if __name__ == "__main__":
     print("Scraping weekly agenda...")
 
     # Example: scrape from week 20 to 21
-    start = datetime.date(2024, 11, 18)
+    start = datetime.date(2025, 5, 20)
     end = datetime.date(2025, 5, 26)
 
     #   entries = scrape_agenda(start_date=start, end_date=end)


### PR DESCRIPTION
- start_requests() is deprecated and causing depreciation logs on render.
- therefore migrated to the newer start() method
- I tested all changed functions - all still work :)

Example log:

```
2025-06-04 09:50:52 - py.warnings - WARNING - /opt/render/project/src/.venv/lib/python3.13/site-packages/scrapy/core/spidermw.py:433: ScrapyDeprecationWarning: app.data_sources.scrapers.polish_presidency_meetings_scraper.PolishPresidencyMeetingsSpider defines the deprecated start_requests() method. start_requests() has been deprecated in favor of a new method, start(), to support asynchronous code execution. start_requests() will stop being called in a future version of Scrapy. If you use Scrapy 2.13 or higher only, replace start_requests() with start(); note that start() is a coroutine (async def). If you need to maintain compatibility with lower Scrapy versions, when overriding start_requests() in a spider class, override start() as well; you can use super() to reuse the inherited start() implementation without copy-pasting. See the release notes of Scrapy 2.13 for details: https://docs.scrapy.org/en/2.13/news.html
``` 