### PR TITLE
296: add new endpoint to get all mep_meetings for given legislative id

### DIFF
--- a/app/api/meetings.py
+++ b/app/api/meetings.py
@@ -192,3 +192,40 @@ def get_meeting_suggestions(
     except Exception as e:
         logger.error("INTERNAL ERROR: %s", e)
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/legislative-files/meetings")
+def get_meetings_by_legislative_id(
+    legislative_id: str = Query(..., description="Legislative procedure reference ID to filter meetings"),
+    limit: int = Query(500, gt=0, le=1000, description="Maximum number of meetings to return"),
+) -> JSONResponse:
+    """
+    Returns all meetings from the mep_meetings table that reference the given legislative (procedure_reference) ID.
+    """
+    try:
+        if not legislative_id or not legislative_id.strip():
+            raise HTTPException(status_code=400, detail="legislative_id must be provided and non-empty.")
+
+        result = (
+            supabase.table("mep_meetings")
+            .select("*")
+            .eq("procedure_reference", legislative_id)
+            .limit(limit)
+            .order("meeting_date")
+            .execute()
+        )
+
+        data = result.data
+        if not isinstance(data, list):
+            raise ValueError("Expected list of records from Supabase")
+
+        logger.info(
+            f"GET /legislative-files/meetings | legislative_id={legislative_id} | returned {len(data)} result(s)"
+        )
+        return JSONResponse(status_code=200, content={"data": data})
+    except HTTPException as he:
+        logger.warning(f"Bad request: {he.detail}")
+        raise he
+    except Exception as e:
+        logger.error(f"INTERNAL ERROR in /legislative-files/meetings: {e}")
+        raise HTTPException(status_code=500, detail="Internal server error.") from e

--- a/app/api/meetings.py
+++ b/app/api/meetings.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from app.core.relevant_meetings import fetch_relevant_meetings
 from app.core.supabase_client import supabase
 from app.core.vector_search import get_top_k_neighbors
-from app.models.meeting import Meeting, MeetingSuggestionResponse, RelevantMeetingsResponse
+from app.models.meeting import Meeting, MeetingSuggestionResponse, LegislativeMeetingsResponse
 
 logger = logging.getLogger(__name__)
 
@@ -151,10 +151,7 @@ def get_meetings(
             # --- USER RELEVANT MEETINGS CASE ---
         if user_id:
             relevant = fetch_relevant_meetings(
-                user_id=user_id,
-                k=limit,
-                query_to_compare=db_query,
-                consider_frequency=False
+                user_id=user_id, k=limit, query_to_compare=db_query, consider_frequency=False
             )
             data = []
             for m in relevant.meetings:
@@ -194,7 +191,7 @@ def get_meeting_suggestions(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("/legislative-files/meetings", response_model=RelevantMeetingsResponse)
+@router.get("/legislative-files/meetings", response_model=LegislativeMeetingsResponse)
 def get_meetings_by_legislative_id(
     legislative_id: str = Query(..., description="Legislative procedure reference ID to filter meetings"),
     limit: int = Query(500, gt=0, le=1000, description="Maximum number of meetings to return"),

--- a/app/api/meetings.py
+++ b/app/api/meetings.py
@@ -200,7 +200,7 @@ def get_meetings_by_legislative_id(
     limit: int = Query(500, gt=0, le=1000, description="Maximum number of meetings to return"),
 ) -> JSONResponse:
     """
-    Returns all meetings from the mep_meetings table that reference the given legislative (procedure_reference) ID.
+    Returns all meetings from the mep_meetings table that reference the given legislative (procedure_reference) ID
     """
     try:
         if not legislative_id or not legislative_id.strip():

--- a/app/api/meetings.py
+++ b/app/api/meetings.py
@@ -8,7 +8,7 @@ from fastapi.responses import JSONResponse
 from app.core.relevant_meetings import fetch_relevant_meetings
 from app.core.supabase_client import supabase
 from app.core.vector_search import get_top_k_neighbors
-from app.models.meeting import Meeting, MeetingSuggestionResponse
+from app.models.meeting import Meeting, MeetingSuggestionResponse, RelevantMeetingsResponse
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ def get_meeting_suggestions(
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.get("/legislative-files/meetings")
+@router.get("/legislative-files/meetings", response_model=RelevantMeetingsResponse)
 def get_meetings_by_legislative_id(
     legislative_id: str = Query(..., description="Legislative procedure reference ID to filter meetings"),
     limit: int = Query(500, gt=0, le=1000, description="Maximum number of meetings to return"),

--- a/app/models/meeting.py
+++ b/app/models/meeting.py
@@ -32,3 +32,20 @@ class RelevantMeetingsResponse(BaseModel):
 
 class MeetingSuggestionResponse(BaseModel):
     data: list[MeetingSuggestion]
+
+
+class LegislativeMeeting(BaseModel):
+    id: str
+    title: str
+    member_name: str
+    meeting_date: datetime
+    meeting_location: str
+    member_capacity: str
+    procedure_reference: Optional[str] = None
+    associated_committee_or_delegation_code: Optional[str] = None
+    associated_committee_or_delegation_name: Optional[str] = None
+    embedding_input: Optional[str] = None
+    scraped_at: datetime
+
+class LegislativeMeetingsResponse(BaseModel):
+    data: list[LegislativeMeeting]


### PR DESCRIPTION
This PR adds a new API endpoint which returns the mep_meetings referencing the specified legislative_id


Closes: #296 