### PR TITLE
feat: add user_id filtering for legislative_files

### DIFF
--- a/app/api/legislative_files.py
+++ b/app/api/legislative_files.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from typing import Optional
 
+from app.core.relevant_legislatives import fetch_relevant_legislative_files
 from app.core.supabase_client import supabase
 from app.core.vector_search import get_top_k_neighbors
 from app.models.legislative_file import LegislativeFilesResponse, LegislativeFileSuggestionResponse
@@ -18,14 +19,25 @@ def get_legislative_files(
     year: Optional[int] = Query(None, description="Filter by reference year (e.g. 2025)"),
     committee: Optional[str] = Query(None, description="Filter by committee name"),
     rapporteur: Optional[str] = Query(None, description="Filter by rapporteur name"),
+    user_id: Optional[str] = Query(None, description="User ID for personalized meeting recommendations"),
 ):
     try:
         if query:
+            if user_id:
+                resp = (
+                    supabase.table("profiles")
+                    .select("company_name,company_description")
+                    .eq("id", user_id)
+                    .single()
+                    .execute()
+                )
+                if resp.data:
+                    query = query + "Profile information: " + str(resp.data)
             neighbors = get_top_k_neighbors(
                 query=query,
                 allowed_sources={"legislative_files": "embedding_input"},
                 k=limit,
-                sources=["document_embeddings"],  # triggers match_filtered
+                sources=["document_embeddings"],
             )
 
             if not neighbors:
@@ -43,19 +55,27 @@ def get_legislative_files(
                 r["similarity"] = similarity_map.get(r["id"])
 
         else:
-            response = supabase.table("legislative_files").select("*").limit(limit).execute()
-            records = response.data or []
+            db_query = supabase.table("legislative_files").select("*")
 
-        # Apply year filtering
-        if year:
-            records = [r for r in records if r.get("id", "").startswith(str(year))]
+            if year:
+                year_prefix = f"{year}%"
+                db_query = db_query.like("id", year_prefix)
 
-        # Apply committee filtering
-        if committee:
-            records = [r for r in records if r.get("committee") == committee]
+            if committee:
+                db_query = db_query.eq("committee", committee)
 
-        if rapporteur:
-            records = [r for r in records if r.get("rapporteur") == rapporteur]
+            if rapporteur:
+                db_query = db_query.eq("rapporteur", rapporteur)
+
+            if user_id:
+                relevant = fetch_relevant_legislative_files(user_id=user_id, query_to_compare=db_query, k=limit)
+                data = []
+                for m in relevant.legislative_files:
+                    data.append(m.model_dump(mode="json"))
+                return JSONResponse(status_code=200, content={"data": data})
+
+            result = db_query.limit(limit).execute()
+            records = result.data or []
 
         return JSONResponse(status_code=200, content={"data": records[:limit]})
 

--- a/app/core/relevant_legislatives.py
+++ b/app/core/relevant_legislatives.py
@@ -1,0 +1,119 @@
+import logging
+from typing import Optional
+
+from openai import OpenAI
+from pydantic import BaseModel, ValidationError
+from datetime import datetime
+
+from app.core.config import Settings
+from postgrest import SyncSelectRequestBuilder
+from app.core.supabase_client import supabase
+from app.core.vector_search import get_top_k_neighbors
+from app.models.legislative_file import LegislativeFile
+
+
+class RelevantLegislativeFilesResponse(BaseModel):
+    legislative_files: list[LegislativeFile]
+
+
+settings = Settings()
+openai = OpenAI(api_key=settings.get_openai_api_key())
+EMBED_MODEL = "text-embedding-ada-002"
+
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_relevant_legislative_files(
+    user_id: str,
+    k: int,
+    query_to_compare: Optional[SyncSelectRequestBuilder] = None,
+) -> RelevantLegislativeFilesResponse:
+    legislative_files: list[LegislativeFile] = []
+    # 1) load the stored profile embedding for `user_id`
+    try:
+        resp = (
+            supabase.table("profiles")
+            .select("embedding", "countries", "newsletter_frequency")
+            .eq("id", user_id)
+            .single()
+            .execute()
+        )
+        profile_embedding = resp.data["embedding"]
+
+    except Exception as e:
+        logger.exception(f"Unexpected error loading profile embedding or profile doesnt exist: {e}")
+        return RelevantLegislativeFilesResponse(legislativeFiles=[])
+
+    # 2) call `get_top_k_neighbors`
+    try:
+        neighbors = get_top_k_neighbors(
+            embedding=profile_embedding,
+            allowed_sources={"legislative_files": "embedding_input"},
+            sources=["document_embeddings"],
+            k=k,
+        )
+
+        if query_to_compare:
+            match = query_to_compare.execute()
+
+            if match.data:
+                allowed_keys = {r["id"] for r in match.data}
+
+                neighbors = [n for n in neighbors if n["source_id"] in allowed_keys]
+
+    except Exception as e:
+        logger.error("Similarity search failed: %s", e)
+        return RelevantLegislativeFilesResponse(legislativeFiles=[])
+    if not neighbors:
+        return RelevantLegislativeFilesResponse(legislativeFiles=[])
+
+    # 3) Fetch the actual legislative files based on the neighbors
+    # Extract source_ids (these are the legislative file ids)
+    source_ids = [n["source_id"] for n in neighbors]
+
+    # Direct query to the legislative_files table
+    try:
+        response = supabase.table("legislative_files").select("*").in_("id", source_ids).execute()
+        rows = response.data
+    except Exception as e:
+        logger.exception(f"Unexpected error fetching legislative files: {e}")
+        return RelevantLegislativeFilesResponse(legislativeFiles=[])
+
+    # Create a map from id to row for easier access
+    fetched = {row["id"]: row for row in rows}
+
+    # 4) assemble ordered list, injecting similarity
+    for n in neighbors:
+        source_id = n["source_id"]
+        row = fetched.get(source_id)
+        if not row:
+            logger.debug(f"No legislative file found for id {source_id}")
+            continue
+
+        # carry over similarity
+        row["similarity"] = n.get("similarity")
+
+        # Fix missing required fields
+        if "source_table" not in row:
+            row["source_table"] = "legislative_files"
+        if "source_id" not in row:
+            row["source_id"] = row["id"]
+
+        # Fix date format
+        if "lastpubdate" in row and isinstance(row["lastpubdate"], str):
+            try:
+                # Parse the string date format
+                parsed_date = datetime.strptime(row["lastpubdate"], "%a %b %d %Y")
+                row["lastpubdate"] = parsed_date.date()
+            except (ValueError, TypeError):
+                # If parsing fails, set to None
+                logger.warning(f"Could not parse date: {row['lastpubdate']}")
+                row["lastpubdate"] = None
+
+        try:
+            legislative_files.append(LegislativeFile.model_validate(row))
+        except ValidationError as ve:
+            logger.warning(f"Skipping invalid legislative file {source_id}: {ve}")
+
+    return RelevantLegislativeFilesResponse(legislativeFiles=legislative_files)


### PR DESCRIPTION
## PR Description

Adds `fetch_relevant_legislative_files` for personalized legislative file recommendations, following the pattern of `fetch_relevant_meetings`. Updates `get_legislative_files` to optionally use user profile embeddings for semantic search while preserving existing filters (year, committee, rapporteur).

- New function: `fetch_relevant_legislative_files`
- Extends personalization to legislative files
- Keeps backwards compatibility with existing queries
