### PR TITLE
improved legislation autocomplete (closes #347), added ec_res_inno_meetings to meetings view (closes #351)

### DIFF
--- a/supabase/migrations/20250708130940_improve-legislation-suggestions-and-update-vmeetings.sql
+++ b/supabase/migrations/20250708130940_improve-legislation-suggestions-and-update-vmeetings.sql
@@ -1,0 +1,309 @@
+set check_function_bodies = off;
+
+insert into public.country_map_meetings (source_table, country, iso2) values
+  ('ec_res_inno_meetings',           'European Union', 'EU')
+on conflict (source_table) do update
+  set country = excluded.country,
+      iso2    = excluded.iso2;
+
+
+CREATE OR REPLACE FUNCTION public.search_legislation_suggestions(search_text text)
+ RETURNS TABLE(id text, title text, similarity_score double precision)
+ LANGUAGE sql
+AS $function$
+  select 
+    id,
+    title,
+    similarity_score
+  from (
+    select 
+      id,
+      title,
+      CASE 
+        WHEN search_text <> '' AND (title ILIKE search_text || '%' OR id ILIKE search_text || '%') THEN 1.0
+        ELSE GREATEST(
+          similarity(title, search_text),
+          similarity(id, search_text)
+        )
+    END AS similarity_score
+    from legislative_files
+    where (title is not null or id is not null)
+  ) scored
+  where similarity_score > 0.1
+  order by similarity_score desc
+  limit 5
+$function$
+;
+
+create or replace view "public"."v_meetings" as  WITH base AS (
+         SELECT (m.id || '_mep_meetings'::text) AS meeting_id,
+            m.id AS source_id,
+            'mep_meetings'::text AS source_table,
+            m.title,
+            (m.meeting_date)::timestamp with time zone AS meeting_start_datetime,
+            NULL::timestamp with time zone AS meeting_end_datetime,
+            m.meeting_location AS exact_location,
+            NULL::text AS description,
+            NULL::text AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            ( SELECT row_to_json(p.*) AS row_to_json
+                   FROM meps p
+                  WHERE (((upper(p.family_name) || ' '::text) || p.given_name) = m.member_name)
+                 LIMIT 1) AS member,
+            ( SELECT string_agg(attendees.name, ';'::text) AS string_agg
+                   FROM (mep_meeting_attendee_mapping mapping
+                     JOIN mep_meeting_attendees attendees ON ((mapping.attendee_id = attendees.id)))
+                  WHERE (mapping.meeting_id = m.id)) AS attendees,
+            m.scraped_at
+           FROM mep_meetings m
+        UNION ALL
+         SELECT (e.id || '_ep_meetings'::text) AS meeting_id,
+            e.id AS source_id,
+            'ep_meetings'::text AS source_table,
+            e.title,
+            (e.datetime AT TIME ZONE 'UTC'::text) AS meeting_start_datetime,
+            NULL::timestamp with time zone AS meeting_end_datetime,
+            e.place AS exact_location,
+            e.subtitles AS description,
+            NULL::text AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            e.scraped_at
+           FROM ep_meetings e
+        UNION ALL
+         SELECT (a.id || '_austrian_parliament'::text) AS meeting_id,
+            a.id AS source_id,
+            'austrian_parliament_meetings'::text AS source_table,
+            a.title,
+            (a.meeting_date)::timestamp with time zone AS meeting_start_datetime,
+            NULL::timestamp with time zone AS meeting_end_datetime,
+            a.meeting_location AS exact_location,
+            a.title_de AS description,
+            a.meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            a.scraped_at
+           FROM austrian_parliament_meetings a
+        UNION ALL
+         SELECT (i.id || '_ipex_events'::text) AS meeting_id,
+            i.id AS source_id,
+            'ipex_events'::text AS source_table,
+            i.title,
+            (i.start_date)::timestamp with time zone AS meeting_start_datetime,
+            (i.end_date)::timestamp with time zone AS meeting_end_datetime,
+            i.meeting_location AS exact_location,
+            NULL::text AS description,
+            NULL::text AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            i.tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            i.scraped_at
+           FROM ipex_events i
+        UNION ALL
+         SELECT (b.id || '_belgian_parliament'::text) AS meeting_id,
+            b.id AS source_id,
+            'belgian_parliament_meetings'::text AS source_table,
+            COALESCE(b.title_en, b.title) AS title,
+            (b.meeting_date)::timestamp with time zone AS meeting_start_datetime,
+            NULL::timestamp with time zone AS meeting_end_datetime,
+            b.location AS exact_location,
+            COALESCE(b.description_en, b.description) AS description,
+            b.meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            b.scraped_at
+           FROM belgian_parliament_meetings b
+        UNION ALL
+         SELECT (p.id || '_mec_prep_bodies'::text) AS meeting_id,
+            p.id AS source_id,
+            'mec_prep_bodies_meeting'::text AS source_table,
+            p.title,
+            (p.meeting_timestamp AT TIME ZONE 'UTC'::text) AS meeting_start_datetime,
+            NULL::timestamp with time zone AS meeting_end_datetime,
+            p.meeting_location AS exact_location,
+            NULL::text AS description,
+            p.url AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            p.scraped_at
+           FROM mec_prep_bodies_meeting p
+        UNION ALL
+         SELECT (s.id || '_mec_summit_ministerial'::text) AS meeting_id,
+            s.id AS source_id,
+            'mec_summit_ministerial_meeting'::text AS source_table,
+            s.title,
+            (s.meeting_date)::timestamp with time zone AS meeting_start_datetime,
+            (s.meeting_end_date)::timestamp with time zone AS meeting_end_datetime,
+            NULL::text AS exact_location,
+            s.category_abbr AS description,
+            s.url AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            s.scraped_at
+           FROM mec_summit_ministerial_meeting s
+        UNION ALL
+         SELECT (p.id || '_polish_presidency'::text) AS meeting_id,
+            p.id AS source_id,
+            'polish_presidency_meeting'::text AS source_table,
+            p.title,
+            (p.meeting_date)::timestamp with time zone AS meeting_start_datetime,
+            (p.meeting_end_date)::timestamp with time zone AS meeting_end_datetime,
+            p.meeting_location AS exact_location,
+            NULL::text AS description,
+            p.meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            p.scraped_at
+           FROM polish_presidency_meeting p
+        UNION ALL
+         SELECT (s.id || '_spanish_commission'::text) AS meeting_id,
+            s.id AS source_id,
+            'spanish_commission_meetings'::text AS source_table,
+            COALESCE(s.title_en, s.title) AS title,
+            ((s.date + COALESCE(
+                CASE
+                    WHEN ((s."time" IS NULL) OR (TRIM(BOTH FROM s."time") = ''::text) OR (lower(TRIM(BOTH FROM s."time")) = 'empty'::text)) THEN NULL::time without time zone
+                    WHEN (TRIM(BOTH FROM s."time") ~ '^(\d{1,2}:\d{2})'::text) THEN ("substring"(TRIM(BOTH FROM s."time"), '^(\d{1,2}:\d{2})'::text))::time without time zone
+                    ELSE NULL::time without time zone
+                END, '00:00:00'::time without time zone)))::timestamp with time zone AS meeting_start_datetime,
+            NULL::timestamp with time zone AS meeting_end_datetime,
+            COALESCE(s.location_en, s.location) AS exact_location,
+            COALESCE(s.description_en, s.description) AS description,
+            s.url AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            NULL::text[] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            s.scraped_at
+           FROM spanish_commission_meetings s
+        UNION ALL
+         SELECT (w.id || '_weekly_agenda'::text) AS meeting_id,
+            w.id AS source_id,
+            'weekly_agenda'::text AS source_table,
+            w.title,
+            ((w.date + COALESCE(
+                CASE
+                    WHEN (w."time" IS NULL) THEN NULL::time without time zone
+                    WHEN (strpos(w."time", '-'::text) > 0) THEN (TRIM(BOTH FROM split_part(w."time", '-'::text, 1)))::time without time zone
+                    ELSE (TRIM(BOTH FROM w."time"))::time without time zone
+                END, '00:00:00'::time without time zone)))::timestamp with time zone AS meeting_start_datetime,
+                CASE
+                    WHEN (strpos(w."time", '-'::text) > 0) THEN (((w.date + (TRIM(BOTH FROM split_part(w."time", '-'::text, 2)))::time without time zone) +
+                    CASE
+                        WHEN ((TRIM(BOTH FROM split_part(w."time", '-'::text, 2)))::time without time zone < (TRIM(BOTH FROM split_part(w."time", '-'::text, 1)))::time without time zone) THEN '1 day'::interval
+                        ELSE '00:00:00'::interval
+                    END))::timestamp with time zone
+                    ELSE NULL::timestamp with time zone
+                END AS meeting_end_datetime,
+            w.location AS exact_location,
+            w.description,
+            NULL::text AS meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            ARRAY[w.type] AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            w.scraped_at
+           FROM weekly_agenda w
+        UNION ALL
+         SELECT (r.id || '_ec_res_inno_meetings'::text) AS meeting_id,
+            r.id AS source_id,
+            'ec_res_inno_meetings'::text AS source_table,
+            r.title,
+            (r.start_date)::timestamp with time zone AS meeting_start_datetime,
+            (r.end_date)::timestamp with time zone AS meeting_end_datetime,
+            r.location AS exact_location,
+            r.description,
+            r.meeting_url,
+            NULL::text AS status,
+            NULL::text AS source_url,
+            r.subjects AS tags,
+            NULL::json AS member,
+            NULL::text AS attendees,
+            r.scraped_at
+           FROM ec_res_inno_meetings r
+        ), base_with_location AS (
+         SELECT base.meeting_id,
+            base.source_id,
+            base.source_table,
+            base.title,
+            base.meeting_start_datetime,
+            base.meeting_end_datetime,
+            base.exact_location,
+            base.description,
+            base.meeting_url,
+            base.status,
+            base.source_url,
+            base.tags,
+            base.member,
+            base.attendees,
+            base.scraped_at,
+            cm.country AS location
+           FROM (base
+             JOIN country_map_meetings cm ON ((base.source_table = cm.source_table)))
+        ), base_with_topic AS (
+         SELECT bwl.meeting_id,
+            bwl.source_id,
+            bwl.source_table,
+            bwl.title,
+            bwl.meeting_start_datetime,
+            bwl.meeting_end_datetime,
+            bwl.exact_location,
+            bwl.description,
+            bwl.meeting_url,
+            bwl.status,
+            bwl.source_url,
+            bwl.tags,
+            bwl.member,
+            bwl.attendees,
+            bwl.scraped_at,
+            bwl.location,
+            mt.topic
+           FROM ((base_with_location bwl
+             LEFT JOIN meeting_topic_assignments mta ON (((mta.source_id = bwl.source_id) AND (mta.source_table = bwl.source_table))))
+             LEFT JOIN meeting_topics mt ON ((mt.id = mta.topic_id)))
+        )
+ SELECT base_with_topic.meeting_id,
+    base_with_topic.source_id,
+    base_with_topic.source_table,
+    base_with_topic.title,
+    base_with_topic.meeting_start_datetime,
+    base_with_topic.meeting_end_datetime,
+    base_with_topic.exact_location,
+    base_with_topic.description,
+    base_with_topic.meeting_url,
+    base_with_topic.status,
+    base_with_topic.source_url,
+    base_with_topic.tags,
+    base_with_topic.member,
+    base_with_topic.attendees,
+    base_with_topic.scraped_at,
+    base_with_topic.location,
+    base_with_topic.topic
+   FROM base_with_topic;
+
+
+

--- a/supabase/schemas/06_country_map_meetings.sql
+++ b/supabase/schemas/06_country_map_meetings.sql
@@ -14,7 +14,8 @@ insert into public.country_map_meetings (source_table, country, iso2) values
   ('mec_summit_ministerial_meeting', 'European Union', 'EU'),
   ('polish_presidency_meeting',      'Poland',         'PL'),
   ('spanish_commission_meetings',    'Spain',          'ES'),
-  ('weekly_agenda',                  'European Union', 'EU')
+  ('weekly_agenda',                  'European Union', 'EU'),
+  ('ec_res_inno_meetings',           'European Union', 'EU')
 on conflict (source_table) do update
   set country = excluded.country,
       iso2    = excluded.iso2;

--- a/supabase/schemas/26_v_meeting.sql
+++ b/supabase/schemas/26_v_meeting.sql
@@ -210,6 +210,8 @@ with base as (
         NULL::text                                 AS status,
         NULL::text                                 AS source_url,
         NULL::text[]                               AS tags,
+        null::json                                 AS member,
+        null::text                                 AS attendees,
         s.scraped_at                               AS scraped_at
     from public.spanish_commission_meetings s
 
@@ -257,6 +259,27 @@ with base as (
         null::text                                   as attendees,
         w.scraped_at                                 as scraped_at
     from public.weekly_agenda w
+
+    union all
+
+    -- EC Res Inno Meetings
+    select
+        r.id || '_ec_res_inno_meetings'             as meeting_id,
+        r.id                                         as source_id,
+        'ec_res_inno_meetings'                      as source_table,
+        r.title                                      as title,
+        r.start_date::timestamptz                    as meeting_start_datetime,
+        r.end_date::timestamptz                      as meeting_end_datetime,
+        r.location                                   as exact_location,
+        r.description                                as description,
+        r.meeting_url                                as meeting_url,
+        null::text                                   as status,
+        null::text                                   as source_url,
+        r.subjects                                   as tags,
+        null::json                                   as member,
+        null::text                                   as attendees,
+        r.scraped_at                                 as scraped_at
+    from public.ec_res_inno_meetings r
 
 ),
 base_with_location AS (

--- a/supabase/schemas/28_search_legislation_suggestions.sql
+++ b/supabase/schemas/28_search_legislation_suggestions.sql
@@ -17,10 +17,13 @@ as $$
     select 
       id,
       title,
-      GREATEST(
-        similarity(title, search_text),
-        similarity(id, search_text)
-      ) as similarity_score
+      CASE 
+        WHEN search_text <> '' AND (title ILIKE search_text || '%' OR id ILIKE search_text || '%') THEN 1.0
+        ELSE GREATEST(
+          similarity(title, search_text),
+          similarity(id, search_text)
+        )
+    END AS similarity_score
     from legislative_files
     where (title is not null or id is not null)
   ) scored

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -915,6 +915,84 @@ VALUES
     'Workshop - Cybersecurity Best Practices - ITRE European Parliament, Brussels Technical workshop on implementing cybersecurity measures'
 );
 
+-- ==========================================
+-- Seed for ec_res_inno_meetings
+-- ==========================================
+INSERT INTO ec_res_inno_meetings (
+    id,
+    title,
+    meeting_url,
+    start_date,
+    end_date,
+    location,
+    event_type,
+    description,
+    subjects,
+    embedding_input
+)
+VALUES
+(
+    'ec_res_inno_001',
+    'European Research and Innovation Days',
+    'https://ec.europa.eu/research-and-innovation/en/events/upcoming-events/research-innovation-days',
+    '2025-09-25',
+    '2025-09-27',
+    'Brussels, Belgium',
+    'Conference',
+    'Annual flagship event bringing together policymakers, researchers, entrepreneurs and citizens to debate and shape the future of research and innovation in Europe.',
+    ARRAY['research policy', 'innovation', 'Horizon Europe'],
+    'European Research and Innovation Days 2025-09-25 2025-09-27 Brussels, Belgium Conference Annual flagship event bringing together policymakers, researchers, entrepreneurs and citizens to debate and shape the future of research and innovation in Europe'
+),
+(
+    'ec_res_inno_002',
+    'Digital Innovation Hubs Annual Forum',
+    'https://ec.europa.eu/research-and-innovation/en/events/upcoming-events/digital-innovation-hubs-forum',
+    '2025-10-12',
+    '2025-10-13',
+    'Porto, Portugal',
+    'Forum',
+    'European gathering of Digital Innovation Hubs to exchange best practices and discuss strategic developments in digital transformation support for SMEs.',
+    ARRAY['digital innovation', 'SMEs', 'Digital Europe Programme'],
+    'Digital Innovation Hubs Annual Forum 2025-10-12 2025-10-13 Porto, Portugal Forum European gathering of Digital Innovation Hubs to exchange best practices and discuss strategic developments in digital transformation support for SMEs'
+),
+(
+    'ec_res_inno_003',
+    'EU Green Tech Investment Summit',
+    'https://ec.europa.eu/research-and-innovation/en/events/upcoming-events/green-tech-summit',
+    '2025-11-05',
+    '2025-11-06',
+    'Vienna, Austria',
+    'Summit',
+    'High-level event bringing together investors, innovators and policymakers to accelerate investment in green technologies across Europe.',
+    ARRAY['green technologies', 'sustainable investment', 'climate neutrality'],
+    'EU Green Tech Investment Summit 2025-11-05 2025-11-06 Vienna, Austria Summit High-level event bringing together investors, innovators and policymakers to accelerate investment in green technologies across Europe'
+),
+(
+    'ec_res_inno_004',
+    'European AI Excellence Conference',
+    'https://ec.europa.eu/research-and-innovation/en/events/upcoming-events/ai-excellence-conference',
+    '2025-11-18',
+    '2025-11-19',
+    'Helsinki, Finland',
+    'Conference',
+    'Conference focusing on European excellence in artificial intelligence research, ethical AI development and regulatory frameworks.',
+    ARRAY['artificial intelligence', 'ethics', 'digital policy'],
+    'European AI Excellence Conference 2025-11-18 2025-11-19 Helsinki, Finland Conference Conference focusing on European excellence in artificial intelligence research, ethical AI development and regulatory frameworks'
+),
+(
+    'ec_res_inno_005',
+    'Horizon Europe Health Cluster Info Day',
+    'https://ec.europa.eu/research-and-innovation/en/events/upcoming-events/health-cluster-infoday',
+    '2025-12-03',
+    '2025-12-03',
+    'Online',
+    'Info Day',
+    'Information day on upcoming funding opportunities in the Horizon Europe Health Cluster, including calls, partnerships and missions.',
+    ARRAY['health research', 'Horizon Europe', 'funding'],
+    'Horizon Europe Health Cluster Info Day 2025-12-03 2025-12-03 Online Info Day Information day on upcoming funding opportunities in the Horizon Europe Health Cluster, including calls, partnerships and missions'
+);
+
+
 
 INSERT INTO meeting_embeddings (
     source_table,


### PR DESCRIPTION
This PR closes #347 & #351 in one migration.

- feat: improve legislation autocomplete by including prefix matches (closes #347)
- feat: added ec_res_inno_meetings to meetings view (closes #351)
- feat: added seed data for ec_res_inno_meetings

Tested locally using `supabase db reset` to check the new migration:
- `SELECT * FROM search_legislation_suggestions('Ex');` returns example rows by prefix matching
- meetings view includes the newly added seed data of ec_res_inno_meetings